### PR TITLE
Add Tool Name in the Tree Node

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -95,6 +95,9 @@ export interface CodeScanningAlert {
   html_url: string;
   state: string;
   rule: CodeScanningRule;
+  tool: {
+    name: string;
+  };
   most_recent_instance: {
     message: {
       text: string;

--- a/src/tree/nodes.ts
+++ b/src/tree/nodes.ts
@@ -99,7 +99,7 @@ export class CodeScanningAlertNode extends TreeNode {
     this.tooltip = new MarkdownString(alert.rule.help || "");
 
     const { path, start_line } = alert.most_recent_instance.location;
-    this.description = `${path}:${start_line}`;
+    this.description = `by ${alert.tool?.name} in ${path}:${start_line}`;
 
     this.command = {
       command: "github-security.openCodeScanningAlertInstance",


### PR DESCRIPTION
Hi. How do you think about showing `Tool` name in the detected code scanning alerts somewhere? (ex. as similar way as repository's Security Tab, if it makes sense)

I was experimenting with the extension on a repository with multiple scanning tools, and it is not clear which alerts are coming from which tool. Each scanning tool has different aspect, and it may be useful to see them along with the alert's severity.

Thank you for reading 🙇 .

## Reference
- Referenced the following API response.
  - [GitHub Docs - REST API - List code scanning alerts for an enterprise](https://docs.github.com/en/rest/code-scanning#list-code-scanning-alerts-for-an-enterprise)

## Screenshots

**After**
<img width="1200" alt="codeql-vscode-01-after" src="https://user-images.githubusercontent.com/1172471/197779481-72c90207-4c6f-4435-aefd-2c6e861dd7ca.png">

**Before**
<img width="1215" alt="codeql-vscode-03-before" src="https://user-images.githubusercontent.com/1172471/197779517-a7dfa2a2-9940-4230-8d0a-f626f1b91bc6.png">

**GitHub GUI**
<img width="953" alt="codeql-vscode-02-gui" src="https://user-images.githubusercontent.com/1172471/197779559-e692569c-eaec-41ba-984a-1c4386bd0f8f.png">
